### PR TITLE
HDF5Object doesn't have a type parameter

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -1493,7 +1493,7 @@ end
 # Create and write, closing the objects upon exit
 for (privatesym, fsym, ptype, crsym) in
     ((:_d_write, :d_write, Union(HDF5File, HDF5Group), :d_create),
-     (:_a_write, :a_write, Union(HDF5File, HDF5Object{HDF5File}, HDF5Datatype), :a_create))
+     (:_a_write, :a_write, Union(HDF5File, HDF5Object, HDF5Datatype), :a_create))
     @eval begin
         # Generic write (hidden)
         function ($privatesym)(parent::$ptype, name::ByteString, data, plists...)


### PR DESCRIPTION
I'm posting this as a pull request mostly because of an interesting discovery: without this fix,
```julia
$ julia --inline=no --check-bounds=yes
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0-dev+2440 (2015-01-03 13:21 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit b365c36* (0 days old master)
|__/                   |  x86_64-linux-gnu

julia> reload("HDF5")
ERROR: type: instantiate_type: expected TypeConstructor, got Type{Union(HDF5.HDF5Dataset,HDF5.HDF5Group,HDF5.HDF5Datatype)}
 in include at ./boot.jl:242
 in include_from_node1 at ./loading.jl:128
 in include at ./boot.jl:242
 in include_from_node1 at ./loading.jl:128
 in reload_path at ./loading.jl:152
 in reload at loading.jl:85
 in eval at no file
while loading /home/tim/.julia/v0.4/HDF5/src/plain.jl, in expression starting on line 1494
while loading /home/tim/.julia/v0.4/HDF5/src/HDF5.jl, in expression starting on line 1
```
It's a bit of a mystery why this package ever loaded.