### PR TITLE
Modernize .travis.yml and fix beginswith->startswith deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,16 @@
-language: cpp
+language: julia
 os:
     - linux
     - osx
-compiler: 
-    - gcc
+julia:
+    - release
+    - nightly
 notifications:
     email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-    - if [ `uname` = "Linux" ]; then
-        sudo add-apt-repository ppa:staticfloat/julia-deps -y;
-        sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y;
-        sudo apt-get update -qq -y;
-        sudo apt-get install libpcre3-dev julia -y;
-      elif [ `uname` = "Darwin" ]; then
-        if [ "$JULIAVERSION" = "julianightlies" ]; then
-          wget -O julia.dmg "http://status.julialang.org/download/osx10.7+";
-        else
-          wget -O julia.dmg "http://status.julialang.org/stable/osx10.7+";
-        fi;
-        hdiutil mount julia.dmg;
-        cp -Ra /Volumes/Julia/*.app/Contents/Resources/julia ~;
-        export PATH="$PATH:$(echo ~)/julia/bin";
-      fi
-    - git config --global user.name "Travis User"
-    - git config --global user.email "travis@example.net"
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
-    - julia -e 'versioninfo(); Pkg.init(); Pkg.add("DataFrames"); Pkg.clone(pwd()); Pkg.build("HDF5")'
-    - if [ $JULIAVERSION = "julianightlies" ]; then julia --code-coverage test/runtests.jl; fi
-    - if [ $JULIAVERSION = "juliareleases" ]; then julia test/runtests.jl; fi
-    - if [ $JULIAVERSION = "julianightlies" ]; then julia -e 'Pkg.add("JLDArchives"); cd(Pkg.dir("JLDArchives", "test")); include("runtests.jl")'; fi
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("HDF5"); Pkg.add("JLDArchives")'
+    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia --check-bounds=yes --inline=no --code-coverage=user -e 'include(Pkg.dir("HDF5", "test", "runtests.jl")); include(Pkg.dir("JLDArchives", "test", "runtests.jl"))'; fi
+    - if [ $TRAVIS_JULIA_VERSION = "release" ]; then julia --check-bounds=yes -e 'Pkg.test("HDF5"); Pkg.test("JLDArchives")'; fi
 after_success:
-    - julia -e 'cd(Pkg.dir("HDF5")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("HDF5")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -188,7 +188,7 @@ function jldopen(filename::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::B
             finally
                 close(rawfid)
             end
-            if beginswith(magic, magic_base.data)
+            if startswith(magic, magic_base.data)
                 version = convert(VersionNumber, bytestring(convert(Ptr{Uint8}, magic) + length(magic_base)))
                 if version < v"0.1.0"
                     if !isdefined(JLD, :JLD00)
@@ -273,7 +273,7 @@ exists(p::Union(JldFile, JldGroup, JldDataset), path::ByteString) = exists(p.pla
 root(p::Union(JldFile, JldGroup, JldDataset)) = g_open(file(p), "/")
 o_delete(parent::Union(JldFile, JldGroup), args...) = o_delete(parent.plain, args...)
 function ensurepathsafe(path::ByteString)
-    if any([beginswith(path, s) for s in (pathrefs,pathtypes,pathrequire)])
+    if any([startswith(path, s) for s in (pathrefs,pathtypes,pathrequire)])
         error("$name is internal to the JLD format, use o_delete if you really want to delete it")
     end
 end
@@ -821,7 +821,7 @@ function full_typename(io::IO, file::JldFile, jltype::DataType)
     if mod != Main
         mname = string(mod)
         for x in file.truncatemodules
-            if beginswith(mname, x)
+            if startswith(mname, x)
                 mname = length(x) == length(mname) ? "" : mname[sizeof(x)+1:end]
                 break
             end

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -3,7 +3,7 @@
 ###############################################
 
 module JLD00
-using HDF5
+using HDF5, Compat
 # Add methods to...
 import HDF5: close, dump, exists, file, getindex, setindex!, g_create, g_open, o_delete, name, names, read, size, write,
              HDF5ReferenceObj, HDF5BitsKind, ismmappable, readmmap
@@ -127,7 +127,7 @@ function jldopen(filename::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::B
             finally
                 close(rawfid)
             end
-            if beginswith(magic, magic_base.data)
+            if startswith(magic, magic_base.data)
                 f = HDF5.h5f_open(filename, wr ? HDF5.H5F_ACC_RDWR : HDF5.H5F_ACC_RDONLY, pa.id)
                 version = bytestring(convert(Ptr{Uint8}, magic) + length(magic_base))
                 fj = JldFile(HDF5File(f, filename), version, true, true, mmaparrays)
@@ -205,7 +205,7 @@ exists(p::Union(JldFile, JldGroup, JldDataset), path::ByteString) = exists(p.pla
 root(p::Union(JldFile, JldGroup, JldDataset)) = g_open(file(p), "/")
 o_delete(parent::Union(JldFile, JldGroup), args...) = o_delete(parent.plain, args...)
 function ensurepathsafe(path::ByteString)
-    if any([beginswith(path, s) for s in (pathrefs,pathtypes,pathrequire)]) 
+    if any([startswith(path, s) for s in (pathrefs,pathtypes,pathrequire)]) 
         error("$name is internal to the JLD format, use o_delete if you really want to delete it") 
     end
 end
@@ -624,7 +624,7 @@ function write{T}(parent::Union(JldFile, JldGroup), path::ByteString, data::Arra
     local refs
     # Determine whether parent already exists in /_refs, so we can avoid group/dataset conflict
     pname = name(parent)
-    if beginswith(pname, pathrefs)
+    if startswith(pname, pathrefs)
         gref = g_create(parent, path*"g")
     else
         pathr = HDF5.joinpathh5(pathrefs, pname, path)


### PR DESCRIPTION
Not sure if I've got the syntax correct, but we'll see. This is more complicated than is typical, because:
- I want to submit to Coveralls only from the nightly build, since I want to use features like `--inline=no`
- I am running the tests for two packages (HDF5 and JLDArchives) in a single session, to make sure the coverage files include the tests of both
