### PR TITLE
Allow literal bitstype and symbol type parameters

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -751,7 +751,7 @@ is_valid_type_ex(s::Symbol) = true
 is_valid_type_ex(s::QuoteNode) = true
 is_valid_type_ex{T}(::T) = isbits(T)
 is_valid_type_ex(e::Expr) = ((e.head == :curly || e.head == :tuple || e.head == :.) && all(map(is_valid_type_ex, e.args))) ||
-                            (e.head == :call && isa(e.args[1], Symbol))
+                            (e.head == :call && (e.args[1] == :Union || e.args[1] == :TypeVar))
 
 # Work around https://github.com/JuliaLang/julia/issues/8226
 const _typedict = Dict{String,Type}()

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -749,9 +749,9 @@ length(x::Union(JldFile, JldGroup)) = length(names(x))
 
 is_valid_type_ex(s::Symbol) = true
 is_valid_type_ex(s::QuoteNode) = true
-is_valid_type_ex(x::Int) = true
+is_valid_type_ex{T}(::T) = isbits(T)
 is_valid_type_ex(e::Expr) = ((e.head == :curly || e.head == :tuple || e.head == :.) && all(map(is_valid_type_ex, e.args))) ||
-                            (e.head == :call && (e.args[1] == :Union || e.args[1] == :TypeVar))
+                            (e.head == :call && isa(e.args[1], Symbol))
 
 # Work around https://github.com/JuliaLang/julia/issues/8226
 const _typedict = Dict{String,Type}()
@@ -816,6 +816,7 @@ function full_typename(io::IO, file::JldFile, jltype::(Type...))
     print(io, ')')
 end
 full_typename(io::IO, ::JldFile, x) = print(io, x)
+full_typename(io::IO, ::JldFile, x::Symbol) = print(io, ":", x) # print(io, ::Symbol) doesn't show the leading colon
 function full_typename(io::IO, file::JldFile, jltype::DataType)
     mod = jltype.name.module
     if mod != Main

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -191,7 +191,6 @@ Sbig = "A test string "^1000
 type BitsParams{x}; end
 bitsparamfloat = BitsParams{1.0}()
 bitsparambool  = BitsParams{true}()
-bitsparamimmut = BitsParams{PaddingTest(1,2)}()
 bitsparamsymbol = BitsParams{:x}()
 
 iseq(x,y) = isequal(x,y)
@@ -370,7 +369,6 @@ for compress in (true,false)
     @write fid Sbig
     @write fid bitsparamfloat
     @write fid bitsparambool
-    @write fid bitsparamimmut
     @write fid bitsparamsymbol
 
     # Make sure we can create groups (i.e., use HDF5 features)
@@ -488,7 +486,6 @@ for compress in (true,false)
         @check fidr Sbig
         @check fidr bitsparamfloat
         @check fidr bitsparambool
-        @check fidr bitsparamimmut
         @check fidr bitsparamsymbol
         
         x1 = read(fidr, "group1/x")

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -187,6 +187,13 @@ Abig = kron(eye(10), rand(20,20))
 Bbig = Any[i for i=1:3000]
 Sbig = "A test string "^1000
 
+# Bitstype type parameters
+type BitsParams{x}; end
+bitsparamfloat = BitsParams{1.0}()
+bitsparambool  = BitsParams{true}()
+bitsparamimmut = BitsParams{PaddingTest(1,2)}()
+bitsparamsymbol = BitsParams{:x}()
+
 iseq(x,y) = isequal(x,y)
 iseq(x::MyStruct, y::MyStruct) = (x.len == y.len && x.data == y.data)
 iseq(x::MyImmutable, y::MyImmutable) = (isequal(x.x, y.x) && isequal(x.y, y.y) && isequal(x.z, y.z))
@@ -361,6 +368,11 @@ for compress in (true,false)
     @write fid Abig
     @write fid Bbig
     @write fid Sbig
+    @write fid bitsparamfloat
+    @write fid bitsparambool
+    @write fid bitsparamimmut
+    @write fid bitsparamsymbol
+
     # Make sure we can create groups (i.e., use HDF5 features)
     g = g_create(fid, "mygroup")
     i = 7
@@ -474,6 +486,10 @@ for compress in (true,false)
         @check fidr Abig
         @check fidr Bbig
         @check fidr Sbig
+        @check fidr bitsparamfloat
+        @check fidr bitsparambool
+        @check fidr bitsparamimmut
+        @check fidr bitsparamsymbol
         
         x1 = read(fidr, "group1/x")
         @assert x1 == Any[1]


### PR DESCRIPTION
Since Julia now allows these, we should, too.  Before:

```julia
julia> using HDF5, JLD
       type Foo{a}; end
       immutable Bar; x::Int; end

julia> save("test.jld", "x", Foo{:x}()); load("test.jld")
WARNING: type Foo{x} not present in workspace; reconstructing
Dict{Union(UTF8String,ASCIIString),Any} with 1 entry:
  "x" => ##Foo{x}#9613()

julia> save("test.jld", "x", Foo{1.0}()); load("test.jld")
ERROR: `is_valid_type_ex` has no method matching is_valid_type_ex(::Float64)
 in map at ./base.jl:189
 in is_valid_type_ex at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:753
 in julia_type at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:772
 in _julia_type at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:763
 in julia_type at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:17
 in jldatatype at /Users/mbauman/.julia/v0.3/HDF5/src/jld_types.jl:612
 in read at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:331
 in read at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:316
 in anonymous at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:977
 in jldopen at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:237
 in load at /Users/mbauman/.julia/v0.3/HDF5/src/JLD.jl:976

julia> save("test.jld", "x", Foo{Bar(1)}); load("test.jld")
WARNING: type Foo{Bar(1)} not present in workspace; reconstructing
Dict{Union(UTF8String,ASCIIString),Any} with 1 entry:
  "x" => ##Foo{Bar(1)}#9675()
```

After:

```julia
julia> save("test.jld", "x", Foo{:x}()); load("test.jld")
Dict{Union(UTF8String,ASCIIString),Any} with 1 entry:
  "x" => Foo{:x}()

julia> save("test.jld", "x", Foo{1.0}()); load("test.jld")
Dict{Union(UTF8String,ASCIIString),Any} with 1 entry:
  "x" => Foo{1.0}()

julia> save("test.jld", "x", Foo{Bar(1)}); load("test.jld") # Edited; this is still unsupported
WARNING: type Foo{Bar(1)} not present in workspace; reconstructing
Dict{Union(UTF8String,ASCIIString),Any} with 1 entry:
  "x" => ##Foo{Bar(1)}#9675()
```