### PR TITLE
Add Pacman as a provider.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,10 +1,11 @@
-using BinDeps 
+using BinDeps
 
 @BinDeps.setup
 
 @linux_only begin
     hdf5 = library_dependency("libhdf5", aliases = ["libhdf5", "libhdf5_serial", "libhdf5_openmpi", "libhdf5_mpich"])
     provides(AptGet, "hdf5-tools", hdf5)
+    provides(Pacman, "hdf5", hdf5)
     provides(Yum, "hdf5", hdf5)
 end
 


### PR DESCRIPTION
I got a nice surprise today when Images.jl installed imagemagick for me. Unfortunately HDF5.jl didn't install it's required lib. I believe this change is all that's needed for that to happen.

I also noticed that I've gone a stripped a whitespace in the file. If you'd rather I didn't I can undo that bit of the change.