### PR TITLE
WIP: adapt method definitions for tuple types

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -625,7 +625,7 @@ function write_ref(parent::JldFile, data, wsession::JldWriteSession)
     # Add reference to reference list
     ref = HDF5ReferenceObj(HDF5.objinfo(dset).addr)
     close(dset)
-    if !isa(data, @compat Tuple) && typeof(data).mutable
+    if !isa(data, Tuple) && typeof(data).mutable
         wsession.h5ref[data] = ref
     end
     ref

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -436,7 +436,7 @@ end
 
 # CompositeKind
 function read(obj::JldDataset, T::DataType)
-    if isempty(T.names) && T.size > 0
+    if isempty(getnames(T)) && T.size > 0
         return read_bitstype(obj, T)
     end
     local x
@@ -453,12 +453,12 @@ function read(obj::JldDataset, T::DataType)
     if length(v) == 0
         x = ccall(:jl_new_struct, Any, (Any,Any...), T)
     else
-        n = T.names
+        n = getnames(T)
         if length(v) != length(n)
             error("Wrong number of fields")
         end
         if !T.mutable
-            x = ccall(:jl_new_structv, Any, (Any,Ptr{Void},UInt32), T, v, length(T.names))
+            x = ccall(:jl_new_structv, Any, (Any,Ptr{Void},UInt32), T, v, length(getnames(T)))
         else
             x = ccall(:jl_new_struct_uninit, Any, (Any,), T)
             for i = 1:length(v)
@@ -720,7 +720,7 @@ write(parent::Union(JldFile, JldGroup), name::ByteString, s; rootmodule="") = wr
 
 function write_composite(parent::Union(JldFile, JldGroup), name::ByteString, s; rootmodule="")
     T = typeof(s)
-    if isempty(T.names)
+    if isempty(getnames(T))
         if T.size > 0
             return write_bitstype(parent, name, s)
         end
@@ -730,7 +730,7 @@ function write_composite(parent::Union(JldFile, JldGroup), name::ByteString, s; 
         return
     end
     Tname = string(T.name.name)
-    n = T.names
+    n = getnames(T)
     local gtypes
     if !exists(file(parent), pathtypes)
         gtypes = g_create(file(parent), pathtypes)
@@ -803,7 +803,7 @@ function has_pointer_field(obj::Tuple, name)
 end
 
 function has_pointer_field(obj, name)
-    names = typeof(obj).names
+    names = getnames(typeof(obj))
     for fieldname in names
         if isdefined(obj, fieldname)
             x = getfield(obj, fieldname)

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -226,7 +226,7 @@ function delete!(parent::Union(JldFile, JldGroup), path::ByteString)
     exists(parent, path) || error("$path does not exist in $parent")
     delete!(parent[path])
 end
-delete!(parent::Union(JldFile, JldGroup), args::(ByteString...)) = for a in args delete!(parent,a) end
+delete!(parent::Union(JldFile, JldGroup), args::Tuple{Vararg{ByteString}}) = for a in args delete!(parent,a) end
 ismmappable(obj::JldDataset) = ismmappable(obj.plain)
 readmmap(obj::JldDataset, args...) = readmmap(obj.plain, args...)
 setindex!(parent::Union(JldFile, JldGroup), val, path::ASCIIString) = write(parent, path, val)
@@ -583,9 +583,9 @@ write(parent::Union(JldFile, JldGroup), name::ByteString, n::Nothing) = write(pa
 # Types
 # the first is needed to avoid an ambiguity warning
 if isdefined(Core, :Top)
-    write{T<:Top}(parent::Union(JldFile, JldGroup), name::ByteString, t::(Type{T}...)) = write(parent, name, Any[t...], "Tuple")
+    write{T<:Top}(parent::Union(JldFile, JldGroup), name::ByteString, t::Tuple{Vararg{Type{T}}}) = write(parent, name, Any[t...], "Tuple")
 else
-    write{T}(parent::Union(JldFile, JldGroup), name::ByteString, t::(Type{T}...)) = write(parent, name, Any[t...], "Tuple")
+    write{T}(parent::Union(JldFile, JldGroup), name::ByteString, t::Tuple{Vararg{Type{T}}}) = write(parent, name, Any[t...], "Tuple")
 end
 write{T}(parent::Union(JldFile, JldGroup), name::ByteString, t::Type{T}) = write(parent, name, nothing, string("Type{", full_typename(t), "}"))
 
@@ -1117,7 +1117,7 @@ function load(filename::AbstractString, varname::AbstractString)
     end
 end
 load(filename::AbstractString, varnames::AbstractString...) = load(filename, varnames)
-function load(filename::AbstractString, varnames::(AbstractString...))
+function load(filename::AbstractString, varnames::Tuple{Vararg{AbstractString}})
     jldopen(filename, "r") do file
         map((var)->read(file, var), varnames)
     end

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -436,7 +436,7 @@ end
 
 # CompositeKind
 function read(obj::JldDataset, T::DataType)
-    if isempty(getnames(T)) && T.size > 0
+    if isempty(fieldnames(T)) && T.size > 0
         return read_bitstype(obj, T)
     end
     local x
@@ -453,12 +453,12 @@ function read(obj::JldDataset, T::DataType)
     if length(v) == 0
         x = ccall(:jl_new_struct, Any, (Any,Any...), T)
     else
-        n = getnames(T)
+        n = fieldnames(T)
         if length(v) != length(n)
             error("Wrong number of fields")
         end
         if !T.mutable
-            x = ccall(:jl_new_structv, Any, (Any,Ptr{Void},UInt32), T, v, length(getnames(T)))
+            x = ccall(:jl_new_structv, Any, (Any,Ptr{Void},UInt32), T, v, length(fieldnames(T)))
         else
             x = ccall(:jl_new_struct_uninit, Any, (Any,), T)
             for i = 1:length(v)
@@ -720,7 +720,7 @@ write(parent::Union(JldFile, JldGroup), name::ByteString, s; rootmodule="") = wr
 
 function write_composite(parent::Union(JldFile, JldGroup), name::ByteString, s; rootmodule="")
     T = typeof(s)
-    if isempty(getnames(T))
+    if isempty(fieldnames(T))
         if T.size > 0
             return write_bitstype(parent, name, s)
         end
@@ -730,7 +730,7 @@ function write_composite(parent::Union(JldFile, JldGroup), name::ByteString, s; 
         return
     end
     Tname = string(T.name.name)
-    n = getnames(T)
+    n = fieldnames(T)
     local gtypes
     if !exists(file(parent), pathtypes)
         gtypes = g_create(file(parent), pathtypes)
@@ -803,7 +803,7 @@ function has_pointer_field(obj::Tuple, name)
 end
 
 function has_pointer_field(obj, name)
-    names = getnames(typeof(obj))
+    names = fieldnames(typeof(obj))
     for fieldname in names
         if isdefined(obj, fieldname)
             x = getfield(obj, fieldname)

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -382,7 +382,7 @@ function h5type(parent::JldFile, T::ANY, commit::Bool)
         id = HDF5.h5t_create(HDF5.H5T_COMPOUND, typeinfo.size)
         for i = 1:length(typeinfo.offsets)
             fielddtype = typeinfo.dtypes[i]
-            HDF5.h5t_insert(id, mangle_name(fielddtype, T.names[i]), typeinfo.offsets[i], fielddtype)
+            HDF5.h5t_insert(id, mangle_name(fielddtype, HDF5.getnames(T)[i]), typeinfo.offsets[i], fielddtype)
         end
     end
 
@@ -410,11 +410,11 @@ function _gen_jlconvert_type(typeinfo::JldTypeInfo, T::ANY)
             push!(args, quote
                 ref = unsafe_load(convert(Ptr{HDF5ReferenceObj}, ptr)+$h5offset)
                 if ref != HDF5.HDF5ReferenceObj_NULL
-                    out.$(T.names[i]) = convert($(T.types[i]), read_ref(file, ref))
+                    out.$(HDF5.getnames(T)[i]) = convert($(T.types[i]), read_ref(file, ref))
                 end
             end)
         else
-            push!(args, :(out.$(T.names[i]) = jlconvert($(T.types[i]), file, ptr+$h5offset)))
+            push!(args, :(out.$(HDF5.getnames(T)[i]) = jlconvert($(T.types[i]), file, ptr+$h5offset)))
         end
     end
     @eval function jlconvert(::Type{$T}, file::JldFile, ptr::Ptr)
@@ -491,7 +491,7 @@ const DONT_STORE_SINGLETON_IMMUTABLES = VERSION >= v"0.4.0-dev+385"
 function gen_jlconvert(typeinfo::JldTypeInfo, T::ANY)
     haskey(JLCONVERT_DEFINED, T) && return
 
-    if isempty(T.names)
+    if isempty(HDF5.getnames(T))
         if T.size == 0
             @eval begin
                 jlconvert(::Type{$T}, ::JldFile, ::Ptr) = $T()
@@ -524,7 +524,7 @@ end
 
 # Whether this datatype should be stored as opaque
 isopaque(t::@compat Tuple{Vararg{Type}}) = isa(t, ())
-isopaque(t::DataType) = isempty(t.names)
+isopaque(t::DataType) = isempty(HDF5.getnames(t))
 
 # The size of this datatype in the HDF5 file (if opaque)
 opaquesize(t::@compat Tuple{Vararg{DataType}}) = 1

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -2134,7 +2134,11 @@ function hdf5array(objtype)
     eltyp = HDF5Datatype(h5t_get_super(objtype.id))
     T = hdf5_to_julia_eltype(eltyp)
     dimsizes = ntuple(nd, i->DimSize{@compat Int(dims[nd-i+1])})  # reverse order
-    FixedArray{T, dimsizes}
+    if VERSION < v"0.4.0-dev+4319"
+        FixedArray{T, dimsizes}
+    else
+        FixedArray{T, Tuple{dimsizes...}}
+    end
 end
 
 ### Property manipulation ###

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -14,12 +14,6 @@ import Base: close, convert, done, dump, eltype, endof, flush, getindex,
 
 include("datafile.jl")
 
-if VERSION < v"0.4.0-dev+4319"
-    getnames(T::DataType) = T.names
-else
-    getnames(T::DataType) = T.name.names
-end
-
 ## C types
 typealias C_time_t Int
 

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -432,9 +432,9 @@ type EmptyArray{T}; end
 
 # Stub types to encode fixed-size arrays for H5T_ARRAY
 immutable DimSize{N}; end  # Int-wrapper (can't use tuple of Int as param)
-immutable FixedArray{T,D<:(DimSize...)}; end
+immutable FixedArray{T,D<:(@compat Tuple{Vararg{DimSize}})}; end
 dimsize{N}(::Type{DimSize{N}}) = N
-size{T,D}(::Type{FixedArray{T,D}}) = map(dimsize, D)::(Int...)
+size{T,D}(::Type{FixedArray{T,D}}) = map(dimsize, D)::(@compat Tuple{Vararg{Int}})
 eltype{T,D}(::Type{FixedArray{T,D}}) = T
 
 # VLEN objects
@@ -593,7 +593,7 @@ function h5read(filename, name::ByteString)
     dat
 end
 
-function h5read(filename, name::ByteString, indices::(Union(Range{Int},Int,Colon)...))
+function h5read(filename, name::ByteString, indices::@compat Tuple{Vararg{Union(Range{Int},Int,Colon)}})
     local dat
     fid = h5open(filename, "r")
     try
@@ -767,7 +767,7 @@ function d_create(parent::Union(HDF5File, HDF5Group), path::ByteString, dtype::H
     HDF5Dataset(h5d_create(parent, path, dtype.id, dspace.id, _link_properties(path), p.id, H5P_DEFAULT), file(parent))
 end
 d_create(parent::Union(HDF5File, HDF5Group), path::ByteString, dtype::HDF5Datatype, dspace_dims::Dims, prop1::ASCIIString, val1, pv...) = d_create(checkvalid(parent), path, dtype, dataspace(dspace_dims), prop1, val1, pv...)
-d_create(parent::Union(HDF5File, HDF5Group), path::ByteString, dtype::HDF5Datatype, dspace_dims::(Dims,Dims), prop1::ASCIIString, val1, pv...) = d_create(checkvalid(parent), path, dtype, dataspace(dspace_dims[1], max_dims=dspace_dims[2]), prop1, val1, pv...)
+d_create(parent::Union(HDF5File, HDF5Group), path::ByteString, dtype::HDF5Datatype, dspace_dims::(@compat Tuple{Dims,Dims}), prop1::ASCIIString, val1, pv...) = d_create(checkvalid(parent), path, dtype, dataspace(dspace_dims[1], max_dims=dspace_dims[2]), prop1, val1, pv...)
 d_create(parent::Union(HDF5File, HDF5Group), path::ByteString, dtype::Type, dspace_dims, prop1::ASCIIString, val1, pv...) = d_create(checkvalid(parent), path, datatype(dtype), dataspace(dspace_dims[1], max_dims=dspace_dims[2]), prop1, val1, pv...)
 
 # Note that H5Tcreate is very different; H5Tcommit is the analog of these others
@@ -889,7 +889,7 @@ function size(obj::Union(HDF5Dataset, HDF5Attribute))
     dspace = dataspace(obj)
     dims, maxdims = get_dims(dspace)
     close(dspace)
-    convert((Int...), dims)
+    convert((@compat Tuple{Vararg{Int}}), dims)
 end
 size(dset::Union(HDF5Dataset, HDF5Attribute), d) = d > ndims(dset) ? 1 : size(dset)[d]
 length(dset::Union(HDF5Dataset, HDF5Attribute)) = prod(size(dset))
@@ -1054,7 +1054,7 @@ dataspace(attr::HDF5Attribute) = HDF5Dataspace(h5a_get_space(checkvalid(attr).id
 
 # Create a dataspace from in-memory types
 dataspace{T<:HDF5BitsKind}(x::T) = HDF5Dataspace(h5s_create(H5S_SCALAR))
-function _dataspace(sz::(Int...), max_dims::Union(Dims, ())=())
+function _dataspace(sz::(@compat Tuple{Vararg{Int}}), max_dims::Union(Dims, @compat Tuple{})=())
     dims = Array(Hsize, length(sz))
     any_zero = false
     for i = 1:length(sz)
@@ -1078,13 +1078,13 @@ function _dataspace(sz::(Int...), max_dims::Union(Dims, ())=())
     end
     HDF5Dataspace(space_id)
 end
-dataspace(A::Array; max_dims::Union(Dims, ())  = ()) = _dataspace(size(A), max_dims)
+dataspace(A::Array; max_dims::Union(Dims, @compat Tuple{}) = ()) = _dataspace(size(A), max_dims)
 dataspace(str::ByteString) = HDF5Dataspace(h5s_create(H5S_SCALAR))
-dataspace(R::Array{HDF5ReferenceObj}; max_dims::Union(Dims, ())=()) = _dataspace(size(R), max_dims)
-dataspace(v::HDF5Vlen; max_dims::Union(Dims, ())=()) = _dataspace(size(v.data), max_dims)
+dataspace(R::Array{HDF5ReferenceObj}; max_dims::Union(Dims, @compat Tuple{})=()) = _dataspace(size(R), max_dims)
+dataspace(v::HDF5Vlen; max_dims::Union(Dims, @compat Tuple{})=()) = _dataspace(size(v.data), max_dims)
 dataspace(n::Nothing) = HDF5Dataspace(h5s_create(H5S_NULL))
-dataspace(sz::Dims; max_dims::Union(Dims, ())=()) = _dataspace(sz, max_dims)
-dataspace(sz1::Int, sz2::Int, sz3::Int...; max_dims::Union(Dims, ())=()) = _dataspace(tuple(sz1, sz2, sz3...), max_dims)
+dataspace(sz::Dims; max_dims::Union(Dims, @compat Tuple{})=()) = _dataspace(sz, max_dims)
+dataspace(sz1::Int, sz2::Int, sz3::Int...; max_dims::Union(Dims, @compat Tuple{})=()) = _dataspace(tuple(sz1, sz2, sz3...), max_dims)
 
 # Get the array dimensions from a dataspace or a dataset
 # Returns both dims and maxdims
@@ -1578,9 +1578,7 @@ function _setindex!(dset::HDF5Dataset,T::Type, X::Array, indices::Union(Range{In
     if !(T.parameters[1]<:HDF5BitsKind)
         error("Dataset indexing (hyperslab) is available only for bits types")
     end
-    if length(X) != prod([length(idxs) for idxs in
-                         filter(idx -> isa(idx, Ranges),
-                                [indices[i] for i in 1:length(indices)])])
+    if length(X) != prod(map(length, indices))
         error("number of elements in range and length of array must be equal")
     end
     if eltype(X) != T.parameters[1]
@@ -1835,7 +1833,7 @@ end
 
 ### Utilities for generating ccall wrapper functions programmatically ###
 
-function ccallexpr(lib::AbstractString, ccallsym::Symbol, outtype, argtypes::Tuple, argsyms::Tuple)
+function ccallexpr(lib::AbstractString, ccallsym::Symbol, outtype, argtypes::(@compat Tuple), argsyms::@compat Tuple)
     ccallargs = Any[Expr(:tuple, Expr(:quote, ccallsym), lib), outtype, Expr(:tuple, argtypes...)]
     ccallargs = ccallsyms(ccallargs, length(argtypes), argsyms)
     Expr(:ccall, ccallargs...)

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -14,6 +14,12 @@ import Base: close, convert, done, dump, eltype, endof, flush, getindex,
 
 include("datafile.jl")
 
+if VERSION < v"0.4.0-dev+4319"
+    getnames(T::DataType) = T.names
+else
+    getnames(T::DataType) = T.name.names
+end
+
 ## C types
 typealias C_time_t Int
 

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -1,4 +1,4 @@
-using HDF5
+using HDF5, Compat
 
 fn = joinpath(tempdir(),"test.h5")
 

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -734,13 +734,13 @@ jldopen(fn, "r") do file
     for i = 1:5
         @test x[i].x.x == i
     end
-    @test HDF5.getnames(typeof(read(file, "x6"))) == (@compat Tuple{})
+    @test isempty(fieldnames(typeof(read(file, "x6"))))
     @test reinterpret(UInt8, read(file, "x7")) == 0x77
 
     x = read(file, "x8")
     @test x.a.x == 2
     @test x.b.x.x == 3
-    @test HDF5.getnames(typeof(x.c)) == (@compat Tuple{})
+    @test isempty(fieldnames(typeof(x.c)))
     @test reinterpret(UInt8, x.d) == 0x12
 
     x = read(file, "x9")
@@ -753,7 +753,7 @@ jldopen(fn, "r") do file
     for i = 1:5
         @test x[2][2][i].x.x == i
     end
-    @test HDF5.getnames(typeof(x[3])) == (@compat Tuple{})
+    @test isempty(fieldnames(typeof(x[3])))
 end
 
 # Issue #176

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -294,241 +294,241 @@ close(fid)
 rm(fn)
 
  
-# for compress in (true,false)
-#     fnc = compress ? fn*".c" : fn # workaround #176
-#     fid = jldopen(fnc, "w", compress=compress)
-#     @write fid x
-#     @write fid A
-#     @write fid Aarray
-#     @write fid str
-#     @write fid stringsA
-#     @write fid stringsU
-#     @write fid strings16
-#     @write fid strings16_2d
-#     @write fid empty_string
-#     @write fid empty_string_array
-#     @write fid empty_array_of_strings
-#     @write fid tf
-#     @write fid TF
-#     @write fid AB
-#     @write fid t
-#     @write fid c
-#     @write fid cint
-#     @write fid C
-#     @write fid emptyA
-#     @write fid emptyB
-#     @write fid ms
-#     @write fid msempty
-#     @write fid sym
-#     @write fid syms
-#     @write fid d
-#     if compress # work around #176
-#         @write fid ex
-#     end
-#     @write fid T
-#     @write fid char
-#     @write fid unicode_char
-#     @write fid α
-#     @write fid β
-#     @write fid vv
-#     @write fid cpus
-#     @write fid rng
-#     @write fid typevar
-#     @write fid typevar_lb
-#     @write fid typevar_ub
-#     @write fid typevar_lb_ub
-#     @write fid undef
-#     @write fid undefs
-#     @write fid ms_undef
-#     @test_throws JLD.PointerException @write fid objwithpointer
-#     @write fid bt
-#     @write fid sa_asc
-#     @write fid sa_utf8
-#     @write fid subarray
-#     @write fid arr_empty_tuple
-#     @write fid emptyimmutable
-#     @write fid emptytype
-#     @write fid arr_emptyimmutable
-#     @write fid arr_emptytype
-#     @write fid emptyii
-#     @write fid emptyit
-#     @write fid emptyti
-#     @write fid emptytt
-#     @write fid emptyiiotherfield
-#     @write fid unicodestruct☺
-#     @write fid array_of_matrices
-#     @write fid tup
-#     @write fid empty_tup
-#     @write fid nonpointerfree_immutable_1
-#     @write fid nonpointerfree_immutable_2
-#     @write fid nonpointerfree_immutable_3
-#     @write fid vague
-#     @write fid bitsunion
-#     @write fid typeunionfield
-#     @write fid genericunionfield
-#     @write fid arr_ref
-#     @write fid obj_ref
-#     @write fid padding_test
-#     @write fid empty_arr_1
-#     @write fid empty_arr_2
-#     @write fid empty_arr_3
-#     @write fid empty_arr_4
-#     @write fid bigdata
-#     @write fid bigfloats
-#     @write fid bigints
-#     @write fid none
-#     @write fid nonearr
-#     @write fid scalar_nothing
-#     @write fid vector_nothing
-#     @write fid Abig
-#     @write fid Bbig
-#     @write fid Sbig
-#     @test_throws ErrorException @write fid bitsparamint16
-#     @write fid bitsparamfloat
-#     @write fid bitsparambool
-#     @write fid bitsparamsymbol
-#     @write fid bitsparamint
-#     @write fid bitsparamuint
-#     @write fid tuple_of_tuples
+for compress in (true,false)
+    fnc = compress ? fn*".c" : fn # workaround #176
+    fid = jldopen(fnc, "w", compress=compress)
+    @write fid x
+    @write fid A
+    @write fid Aarray
+    @write fid str
+    @write fid stringsA
+    @write fid stringsU
+    @write fid strings16
+    @write fid strings16_2d
+    @write fid empty_string
+    @write fid empty_string_array
+    @write fid empty_array_of_strings
+    @write fid tf
+    @write fid TF
+    @write fid AB
+    @write fid t
+    @write fid c
+    @write fid cint
+    @write fid C
+    @write fid emptyA
+    @write fid emptyB
+    @write fid ms
+    @write fid msempty
+    @write fid sym
+    @write fid syms
+    @write fid d
+    if compress # work around #176
+        @write fid ex
+    end
+    @write fid T
+    @write fid char
+    @write fid unicode_char
+    @write fid α
+    @write fid β
+    @write fid vv
+    @write fid cpus
+    @write fid rng
+    @write fid typevar
+    @write fid typevar_lb
+    @write fid typevar_ub
+    @write fid typevar_lb_ub
+    @write fid undef
+    @write fid undefs
+    @write fid ms_undef
+    @test_throws JLD.PointerException @write fid objwithpointer
+    @write fid bt
+    @write fid sa_asc
+    @write fid sa_utf8
+    @write fid subarray
+    @write fid arr_empty_tuple
+    @write fid emptyimmutable
+    @write fid emptytype
+    @write fid arr_emptyimmutable
+    @write fid arr_emptytype
+    @write fid emptyii
+    @write fid emptyit
+    @write fid emptyti
+    @write fid emptytt
+    @write fid emptyiiotherfield
+    @write fid unicodestruct☺
+    @write fid array_of_matrices
+    @write fid tup
+    @write fid empty_tup
+    @write fid nonpointerfree_immutable_1
+    @write fid nonpointerfree_immutable_2
+    @write fid nonpointerfree_immutable_3
+    @write fid vague
+    @write fid bitsunion
+    @write fid typeunionfield
+    @write fid genericunionfield
+    @write fid arr_ref
+    @write fid obj_ref
+    @write fid padding_test
+    @write fid empty_arr_1
+    @write fid empty_arr_2
+    @write fid empty_arr_3
+    @write fid empty_arr_4
+    @write fid bigdata
+    @write fid bigfloats
+    @write fid bigints
+    @write fid none
+    @write fid nonearr
+    @write fid scalar_nothing
+    @write fid vector_nothing
+    @write fid Abig
+    @write fid Bbig
+    @write fid Sbig
+    @test_throws ErrorException @write fid bitsparamint16
+    @write fid bitsparamfloat
+    @write fid bitsparambool
+    @write fid bitsparamsymbol
+    @write fid bitsparamint
+    @write fid bitsparamuint
+    @write fid tuple_of_tuples
 
-#     # Make sure we can create groups (i.e., use HDF5 features)
-#     g = g_create(fid, "mygroup")
-#     i = 7
-#     @write g i
-#     write(fid, "group1/x", Any[1])
-#     write(fid, "group2/x", Any[2])
-#     close(fid)
+    # Make sure we can create groups (i.e., use HDF5 features)
+    g = g_create(fid, "mygroup")
+    i = 7
+    @write g i
+    write(fid, "group1/x", Any[1])
+    write(fid, "group2/x", Any[2])
+    close(fid)
 
-#     # mmapping currently fails on Windows; re-enable once it can work
-#     for mmap = (@windows ? false : (false, true))
-#         fidr = jldopen(fnc, "r", mmaparrays=mmap)
-#         @check fidr x
-#         @check fidr A
-#         dsetA = fidr["A"]
-#         @test ndims(dsetA) == ndims(A)
-#         @test size(dsetA) == size(A)
-#         @test size(dsetA, 1) == size(A, 1)
-#         @test size(dsetA, 2) == size(A, 2)
-#         @test size(dsetA, 3) == size(A, 3)
-#         @check fidr Aarray
-#         @check fidr str
-#         @check fidr stringsA
-#         @check fidr stringsU
-#         @check fidr strings16
-#         @check fidr strings16_2d
-#         @check fidr empty_string
-#         @check fidr empty_string_array
-#         @check fidr empty_array_of_strings
-#         @check fidr tf
-#         @check fidr TF
-#         @check fidr AB
-#         @check fidr t
-#         @check fidr c
-#         @check fidr cint
-#         @check fidr C
-#         @check fidr emptyA
-#         @check fidr emptyB
-#         @check fidr ms
-#         @check fidr msempty
-#         @check fidr sym
-#         @check fidr syms
-#         @check fidr d
-#         if compress # work around #176
-#             exr = read(fidr, "ex")   # line numbers are stripped, don't expect equality
-#             checkexpr(ex, exr)
-#         end
-#         @check fidr T
-#         @check fidr char
-#         @check fidr unicode_char
-#         @check fidr α
-#         @check fidr β
-#         @check fidr vv
-#         @check fidr cpus
-#         @check fidr rng
-#         @check fidr typevar
-#         @check fidr typevar_lb
-#         @check fidr typevar_ub
-#         @check fidr typevar_lb_ub
+    # mmapping currently fails on Windows; re-enable once it can work
+    for mmap = (@windows ? false : (false, true))
+        fidr = jldopen(fnc, "r", mmaparrays=mmap)
+        @check fidr x
+        @check fidr A
+        dsetA = fidr["A"]
+        @test ndims(dsetA) == ndims(A)
+        @test size(dsetA) == size(A)
+        @test size(dsetA, 1) == size(A, 1)
+        @test size(dsetA, 2) == size(A, 2)
+        @test size(dsetA, 3) == size(A, 3)
+        @check fidr Aarray
+        @check fidr str
+        @check fidr stringsA
+        @check fidr stringsU
+        @check fidr strings16
+        @check fidr strings16_2d
+        @check fidr empty_string
+        @check fidr empty_string_array
+        @check fidr empty_array_of_strings
+        @check fidr tf
+        @check fidr TF
+        @check fidr AB
+        @check fidr t
+        @check fidr c
+        @check fidr cint
+        @check fidr C
+        @check fidr emptyA
+        @check fidr emptyB
+        @check fidr ms
+        @check fidr msempty
+        @check fidr sym
+        @check fidr syms
+        @check fidr d
+        if compress # work around #176
+            exr = read(fidr, "ex")   # line numbers are stripped, don't expect equality
+            checkexpr(ex, exr)
+        end
+        @check fidr T
+        @check fidr char
+        @check fidr unicode_char
+        @check fidr α
+        @check fidr β
+        @check fidr vv
+        @check fidr cpus
+        @check fidr rng
+        @check fidr typevar
+        @check fidr typevar_lb
+        @check fidr typevar_ub
+        @check fidr typevar_lb_ub
         
-#         # Special cases for reading undefs
-#         undef = read(fidr, "undef")
-#         if !isa(undef, Array{Any, 1}) || length(undef) != 1 || isdefined(undef, 1)
-#             error("For undef, read value does not agree with written value")
-#         end
-#         undefs = read(fidr, "undefs")
-#         if !isa(undefs, Array{Any, 2}) || length(undefs) != 4 || any(map(i->isdefined(undefs, i), 1:4))
-#             error("For undefs, read value does not agree with written value")
-#         end
-#         ms_undef = read(fidr, "ms_undef")
-#         if !isa(ms_undef, MyStruct) || ms_undef.len != 0 || isdefined(ms_undef, :data)
-#             error("For ms_undef, read value does not agree with written value")
-#         end
+        # Special cases for reading undefs
+        undef = read(fidr, "undef")
+        if !isa(undef, Array{Any, 1}) || length(undef) != 1 || isdefined(undef, 1)
+            error("For undef, read value does not agree with written value")
+        end
+        undefs = read(fidr, "undefs")
+        if !isa(undefs, Array{Any, 2}) || length(undefs) != 4 || any(map(i->isdefined(undefs, i), 1:4))
+            error("For undefs, read value does not agree with written value")
+        end
+        ms_undef = read(fidr, "ms_undef")
+        if !isa(ms_undef, MyStruct) || ms_undef.len != 0 || isdefined(ms_undef, :data)
+            error("For ms_undef, read value does not agree with written value")
+        end
         
-#         @check fidr bt
-#         @check fidr sa_asc
-#         @check fidr sa_utf8
-#         @check fidr subarray
-#         @check fidr arr_empty_tuple
-#         @check fidr emptyimmutable
-#         @check fidr emptytype
-#         @check fidr arr_emptyimmutable
-#         @check fidr arr_emptytype
-#         @check fidr emptyii
-#         @check fidr emptyit
-#         @check fidr emptyti
-#         @check fidr emptytt
-#         @check fidr emptyiiotherfield
-#         @check fidr unicodestruct☺
-#         @check fidr array_of_matrices
-#         @check fidr tup
-#         @check fidr empty_tup
-#         @check fidr nonpointerfree_immutable_1
-#         @check fidr nonpointerfree_immutable_2
-#         @check fidr nonpointerfree_immutable_3
-#         vaguer = read(fidr, "vague")
-#         @test typeof(vaguer) == typeof(vague) && vaguer.name == vague.name
-#         @check fidr bitsunion
-#         @check fidr typeunionfield
-#         @check fidr genericunionfield
+        @check fidr bt
+        @check fidr sa_asc
+        @check fidr sa_utf8
+        @check fidr subarray
+        @check fidr arr_empty_tuple
+        @check fidr emptyimmutable
+        @check fidr emptytype
+        @check fidr arr_emptyimmutable
+        @check fidr arr_emptytype
+        @check fidr emptyii
+        @check fidr emptyit
+        @check fidr emptyti
+        @check fidr emptytt
+        @check fidr emptyiiotherfield
+        @check fidr unicodestruct☺
+        @check fidr array_of_matrices
+        @check fidr tup
+        @check fidr empty_tup
+        @check fidr nonpointerfree_immutable_1
+        @check fidr nonpointerfree_immutable_2
+        @check fidr nonpointerfree_immutable_3
+        vaguer = read(fidr, "vague")
+        @test typeof(vaguer) == typeof(vague) && vaguer.name == vague.name
+        @check fidr bitsunion
+        @check fidr typeunionfield
+        @check fidr genericunionfield
         
-#         arr = read(fidr, "arr_ref")
-#         @test arr == arr_ref
-#         @test arr[1] === arr[2]
+        arr = read(fidr, "arr_ref")
+        @test arr == arr_ref
+        @test arr[1] === arr[2]
         
-#         obj = read(fidr, "obj_ref")
-#         @test obj.x.x === obj.x.y == obj.y.x === obj.y.y
-#         @test obj.x !== obj.y
+        obj = read(fidr, "obj_ref")
+        @test obj.x.x === obj.x.y == obj.y.x === obj.y.y
+        @test obj.x !== obj.y
         
-#         @check fidr padding_test
-#         @check fidr empty_arr_1
-#         @check fidr empty_arr_2
-#         @check fidr empty_arr_3
-#         @check fidr empty_arr_4
-#         @check fidr bigdata
-#         @check fidr bigfloats
-#         @check fidr bigints
-#         @check fidr none
-#         @check fidr nonearr
-#         @check fidr scalar_nothing
-#         @check fidr vector_nothing
-#         @check fidr Abig
-#         @check fidr Bbig
-#         @check fidr Sbig
-#         @check fidr bitsparamfloat
-#         @check fidr bitsparambool
-#         @check fidr bitsparamsymbol
-#         @check fidr bitsparamint
-#         @check fidr bitsparamuint
-#         @check fidr tuple_of_tuples
+        @check fidr padding_test
+        @check fidr empty_arr_1
+        @check fidr empty_arr_2
+        @check fidr empty_arr_3
+        @check fidr empty_arr_4
+        @check fidr bigdata
+        @check fidr bigfloats
+        @check fidr bigints
+        @check fidr none
+        @check fidr nonearr
+        @check fidr scalar_nothing
+        @check fidr vector_nothing
+        @check fidr Abig
+        @check fidr Bbig
+        @check fidr Sbig
+        @check fidr bitsparamfloat
+        @check fidr bitsparambool
+        @check fidr bitsparamsymbol
+        @check fidr bitsparamint
+        @check fidr bitsparamuint
+        @check fidr tuple_of_tuples
         
-#         x1 = read(fidr, "group1/x")
-#         @assert x1 == Any[1]
-#         x2 = read(fidr, "group2/x")
-#         @assert x2 == Any[2]
+        x1 = read(fidr, "group1/x")
+        @assert x1 == Any[1]
+        x2 = read(fidr, "group2/x")
+        @assert x2 == Any[2]
         
-#         close(fidr)
-#     end
-# end # compress in (true,false)
+        close(fidr)
+    end
+end # compress in (true,false)
 
 for compress in (false,true)
     # object references in a write session

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -294,241 +294,241 @@ close(fid)
 rm(fn)
 
  
-for compress in (true,false)
-    fnc = compress ? fn*".c" : fn # workaround #176
-    fid = jldopen(fnc, "w", compress=compress)
-    @write fid x
-    @write fid A
-    @write fid Aarray
-    @write fid str
-    @write fid stringsA
-    @write fid stringsU
-    @write fid strings16
-    @write fid strings16_2d
-    @write fid empty_string
-    @write fid empty_string_array
-    @write fid empty_array_of_strings
-    @write fid tf
-    @write fid TF
-    @write fid AB
-    @write fid t
-    @write fid c
-    @write fid cint
-    @write fid C
-    @write fid emptyA
-    @write fid emptyB
-    @write fid ms
-    @write fid msempty
-    @write fid sym
-    @write fid syms
-    @write fid d
-    if compress # work around #176
-        @write fid ex
-    end
-    @write fid T
-    @write fid char
-    @write fid unicode_char
-    @write fid α
-    @write fid β
-    @write fid vv
-    @write fid cpus
-    @write fid rng
-    @write fid typevar
-    @write fid typevar_lb
-    @write fid typevar_ub
-    @write fid typevar_lb_ub
-    @write fid undef
-    @write fid undefs
-    @write fid ms_undef
-    @test_throws JLD.PointerException @write fid objwithpointer
-    @write fid bt
-    @write fid sa_asc
-    @write fid sa_utf8
-    @write fid subarray
-    @write fid arr_empty_tuple
-    @write fid emptyimmutable
-    @write fid emptytype
-    @write fid arr_emptyimmutable
-    @write fid arr_emptytype
-    @write fid emptyii
-    @write fid emptyit
-    @write fid emptyti
-    @write fid emptytt
-    @write fid emptyiiotherfield
-    @write fid unicodestruct☺
-    @write fid array_of_matrices
-    @write fid tup
-    @write fid empty_tup
-    @write fid nonpointerfree_immutable_1
-    @write fid nonpointerfree_immutable_2
-    @write fid nonpointerfree_immutable_3
-    @write fid vague
-    @write fid bitsunion
-    @write fid typeunionfield
-    @write fid genericunionfield
-    @write fid arr_ref
-    @write fid obj_ref
-    @write fid padding_test
-    @write fid empty_arr_1
-    @write fid empty_arr_2
-    @write fid empty_arr_3
-    @write fid empty_arr_4
-    @write fid bigdata
-    @write fid bigfloats
-    @write fid bigints
-    @write fid none
-    @write fid nonearr
-    @write fid scalar_nothing
-    @write fid vector_nothing
-    @write fid Abig
-    @write fid Bbig
-    @write fid Sbig
-    @test_throws ErrorException @write fid bitsparamint16
-    @write fid bitsparamfloat
-    @write fid bitsparambool
-    @write fid bitsparamsymbol
-    @write fid bitsparamint
-    @write fid bitsparamuint
-    @write fid tuple_of_tuples
+# for compress in (true,false)
+#     fnc = compress ? fn*".c" : fn # workaround #176
+#     fid = jldopen(fnc, "w", compress=compress)
+#     @write fid x
+#     @write fid A
+#     @write fid Aarray
+#     @write fid str
+#     @write fid stringsA
+#     @write fid stringsU
+#     @write fid strings16
+#     @write fid strings16_2d
+#     @write fid empty_string
+#     @write fid empty_string_array
+#     @write fid empty_array_of_strings
+#     @write fid tf
+#     @write fid TF
+#     @write fid AB
+#     @write fid t
+#     @write fid c
+#     @write fid cint
+#     @write fid C
+#     @write fid emptyA
+#     @write fid emptyB
+#     @write fid ms
+#     @write fid msempty
+#     @write fid sym
+#     @write fid syms
+#     @write fid d
+#     if compress # work around #176
+#         @write fid ex
+#     end
+#     @write fid T
+#     @write fid char
+#     @write fid unicode_char
+#     @write fid α
+#     @write fid β
+#     @write fid vv
+#     @write fid cpus
+#     @write fid rng
+#     @write fid typevar
+#     @write fid typevar_lb
+#     @write fid typevar_ub
+#     @write fid typevar_lb_ub
+#     @write fid undef
+#     @write fid undefs
+#     @write fid ms_undef
+#     @test_throws JLD.PointerException @write fid objwithpointer
+#     @write fid bt
+#     @write fid sa_asc
+#     @write fid sa_utf8
+#     @write fid subarray
+#     @write fid arr_empty_tuple
+#     @write fid emptyimmutable
+#     @write fid emptytype
+#     @write fid arr_emptyimmutable
+#     @write fid arr_emptytype
+#     @write fid emptyii
+#     @write fid emptyit
+#     @write fid emptyti
+#     @write fid emptytt
+#     @write fid emptyiiotherfield
+#     @write fid unicodestruct☺
+#     @write fid array_of_matrices
+#     @write fid tup
+#     @write fid empty_tup
+#     @write fid nonpointerfree_immutable_1
+#     @write fid nonpointerfree_immutable_2
+#     @write fid nonpointerfree_immutable_3
+#     @write fid vague
+#     @write fid bitsunion
+#     @write fid typeunionfield
+#     @write fid genericunionfield
+#     @write fid arr_ref
+#     @write fid obj_ref
+#     @write fid padding_test
+#     @write fid empty_arr_1
+#     @write fid empty_arr_2
+#     @write fid empty_arr_3
+#     @write fid empty_arr_4
+#     @write fid bigdata
+#     @write fid bigfloats
+#     @write fid bigints
+#     @write fid none
+#     @write fid nonearr
+#     @write fid scalar_nothing
+#     @write fid vector_nothing
+#     @write fid Abig
+#     @write fid Bbig
+#     @write fid Sbig
+#     @test_throws ErrorException @write fid bitsparamint16
+#     @write fid bitsparamfloat
+#     @write fid bitsparambool
+#     @write fid bitsparamsymbol
+#     @write fid bitsparamint
+#     @write fid bitsparamuint
+#     @write fid tuple_of_tuples
 
-    # Make sure we can create groups (i.e., use HDF5 features)
-    g = g_create(fid, "mygroup")
-    i = 7
-    @write g i
-    write(fid, "group1/x", Any[1])
-    write(fid, "group2/x", Any[2])
-    close(fid)
+#     # Make sure we can create groups (i.e., use HDF5 features)
+#     g = g_create(fid, "mygroup")
+#     i = 7
+#     @write g i
+#     write(fid, "group1/x", Any[1])
+#     write(fid, "group2/x", Any[2])
+#     close(fid)
 
-    # mmapping currently fails on Windows; re-enable once it can work
-    for mmap = (@windows ? false : (false, true))
-        fidr = jldopen(fnc, "r", mmaparrays=mmap)
-        @check fidr x
-        @check fidr A
-        dsetA = fidr["A"]
-        @test ndims(dsetA) == ndims(A)
-        @test size(dsetA) == size(A)
-        @test size(dsetA, 1) == size(A, 1)
-        @test size(dsetA, 2) == size(A, 2)
-        @test size(dsetA, 3) == size(A, 3)
-        @check fidr Aarray
-        @check fidr str
-        @check fidr stringsA
-        @check fidr stringsU
-        @check fidr strings16
-        @check fidr strings16_2d
-        @check fidr empty_string
-        @check fidr empty_string_array
-        @check fidr empty_array_of_strings
-        @check fidr tf
-        @check fidr TF
-        @check fidr AB
-        @check fidr t
-        @check fidr c
-        @check fidr cint
-        @check fidr C
-        @check fidr emptyA
-        @check fidr emptyB
-        @check fidr ms
-        @check fidr msempty
-        @check fidr sym
-        @check fidr syms
-        @check fidr d
-        if compress # work around #176
-            exr = read(fidr, "ex")   # line numbers are stripped, don't expect equality
-            checkexpr(ex, exr)
-        end
-        @check fidr T
-        @check fidr char
-        @check fidr unicode_char
-        @check fidr α
-        @check fidr β
-        @check fidr vv
-        @check fidr cpus
-        @check fidr rng
-        @check fidr typevar
-        @check fidr typevar_lb
-        @check fidr typevar_ub
-        @check fidr typevar_lb_ub
+#     # mmapping currently fails on Windows; re-enable once it can work
+#     for mmap = (@windows ? false : (false, true))
+#         fidr = jldopen(fnc, "r", mmaparrays=mmap)
+#         @check fidr x
+#         @check fidr A
+#         dsetA = fidr["A"]
+#         @test ndims(dsetA) == ndims(A)
+#         @test size(dsetA) == size(A)
+#         @test size(dsetA, 1) == size(A, 1)
+#         @test size(dsetA, 2) == size(A, 2)
+#         @test size(dsetA, 3) == size(A, 3)
+#         @check fidr Aarray
+#         @check fidr str
+#         @check fidr stringsA
+#         @check fidr stringsU
+#         @check fidr strings16
+#         @check fidr strings16_2d
+#         @check fidr empty_string
+#         @check fidr empty_string_array
+#         @check fidr empty_array_of_strings
+#         @check fidr tf
+#         @check fidr TF
+#         @check fidr AB
+#         @check fidr t
+#         @check fidr c
+#         @check fidr cint
+#         @check fidr C
+#         @check fidr emptyA
+#         @check fidr emptyB
+#         @check fidr ms
+#         @check fidr msempty
+#         @check fidr sym
+#         @check fidr syms
+#         @check fidr d
+#         if compress # work around #176
+#             exr = read(fidr, "ex")   # line numbers are stripped, don't expect equality
+#             checkexpr(ex, exr)
+#         end
+#         @check fidr T
+#         @check fidr char
+#         @check fidr unicode_char
+#         @check fidr α
+#         @check fidr β
+#         @check fidr vv
+#         @check fidr cpus
+#         @check fidr rng
+#         @check fidr typevar
+#         @check fidr typevar_lb
+#         @check fidr typevar_ub
+#         @check fidr typevar_lb_ub
         
-        # Special cases for reading undefs
-        undef = read(fidr, "undef")
-        if !isa(undef, Array{Any, 1}) || length(undef) != 1 || isdefined(undef, 1)
-            error("For undef, read value does not agree with written value")
-        end
-        undefs = read(fidr, "undefs")
-        if !isa(undefs, Array{Any, 2}) || length(undefs) != 4 || any(map(i->isdefined(undefs, i), 1:4))
-            error("For undefs, read value does not agree with written value")
-        end
-        ms_undef = read(fidr, "ms_undef")
-        if !isa(ms_undef, MyStruct) || ms_undef.len != 0 || isdefined(ms_undef, :data)
-            error("For ms_undef, read value does not agree with written value")
-        end
+#         # Special cases for reading undefs
+#         undef = read(fidr, "undef")
+#         if !isa(undef, Array{Any, 1}) || length(undef) != 1 || isdefined(undef, 1)
+#             error("For undef, read value does not agree with written value")
+#         end
+#         undefs = read(fidr, "undefs")
+#         if !isa(undefs, Array{Any, 2}) || length(undefs) != 4 || any(map(i->isdefined(undefs, i), 1:4))
+#             error("For undefs, read value does not agree with written value")
+#         end
+#         ms_undef = read(fidr, "ms_undef")
+#         if !isa(ms_undef, MyStruct) || ms_undef.len != 0 || isdefined(ms_undef, :data)
+#             error("For ms_undef, read value does not agree with written value")
+#         end
         
-        @check fidr bt
-        @check fidr sa_asc
-        @check fidr sa_utf8
-        @check fidr subarray
-        @check fidr arr_empty_tuple
-        @check fidr emptyimmutable
-        @check fidr emptytype
-        @check fidr arr_emptyimmutable
-        @check fidr arr_emptytype
-        @check fidr emptyii
-        @check fidr emptyit
-        @check fidr emptyti
-        @check fidr emptytt
-        @check fidr emptyiiotherfield
-        @check fidr unicodestruct☺
-        @check fidr array_of_matrices
-        @check fidr tup
-        @check fidr empty_tup
-        @check fidr nonpointerfree_immutable_1
-        @check fidr nonpointerfree_immutable_2
-        @check fidr nonpointerfree_immutable_3
-        vaguer = read(fidr, "vague")
-        @test typeof(vaguer) == typeof(vague) && vaguer.name == vague.name
-        @check fidr bitsunion
-        @check fidr typeunionfield
-        @check fidr genericunionfield
+#         @check fidr bt
+#         @check fidr sa_asc
+#         @check fidr sa_utf8
+#         @check fidr subarray
+#         @check fidr arr_empty_tuple
+#         @check fidr emptyimmutable
+#         @check fidr emptytype
+#         @check fidr arr_emptyimmutable
+#         @check fidr arr_emptytype
+#         @check fidr emptyii
+#         @check fidr emptyit
+#         @check fidr emptyti
+#         @check fidr emptytt
+#         @check fidr emptyiiotherfield
+#         @check fidr unicodestruct☺
+#         @check fidr array_of_matrices
+#         @check fidr tup
+#         @check fidr empty_tup
+#         @check fidr nonpointerfree_immutable_1
+#         @check fidr nonpointerfree_immutable_2
+#         @check fidr nonpointerfree_immutable_3
+#         vaguer = read(fidr, "vague")
+#         @test typeof(vaguer) == typeof(vague) && vaguer.name == vague.name
+#         @check fidr bitsunion
+#         @check fidr typeunionfield
+#         @check fidr genericunionfield
         
-        arr = read(fidr, "arr_ref")
-        @test arr == arr_ref
-        @test arr[1] === arr[2]
+#         arr = read(fidr, "arr_ref")
+#         @test arr == arr_ref
+#         @test arr[1] === arr[2]
         
-        obj = read(fidr, "obj_ref")
-        @test obj.x.x === obj.x.y == obj.y.x === obj.y.y
-        @test obj.x !== obj.y
+#         obj = read(fidr, "obj_ref")
+#         @test obj.x.x === obj.x.y == obj.y.x === obj.y.y
+#         @test obj.x !== obj.y
         
-        @check fidr padding_test
-        @check fidr empty_arr_1
-        @check fidr empty_arr_2
-        @check fidr empty_arr_3
-        @check fidr empty_arr_4
-        @check fidr bigdata
-        @check fidr bigfloats
-        @check fidr bigints
-        @check fidr none
-        @check fidr nonearr
-        @check fidr scalar_nothing
-        @check fidr vector_nothing
-        @check fidr Abig
-        @check fidr Bbig
-        @check fidr Sbig
-        @check fidr bitsparamfloat
-        @check fidr bitsparambool
-        @check fidr bitsparamsymbol
-        @check fidr bitsparamint
-        @check fidr bitsparamuint
-        @check fidr tuple_of_tuples
+#         @check fidr padding_test
+#         @check fidr empty_arr_1
+#         @check fidr empty_arr_2
+#         @check fidr empty_arr_3
+#         @check fidr empty_arr_4
+#         @check fidr bigdata
+#         @check fidr bigfloats
+#         @check fidr bigints
+#         @check fidr none
+#         @check fidr nonearr
+#         @check fidr scalar_nothing
+#         @check fidr vector_nothing
+#         @check fidr Abig
+#         @check fidr Bbig
+#         @check fidr Sbig
+#         @check fidr bitsparamfloat
+#         @check fidr bitsparambool
+#         @check fidr bitsparamsymbol
+#         @check fidr bitsparamint
+#         @check fidr bitsparamuint
+#         @check fidr tuple_of_tuples
         
-        x1 = read(fidr, "group1/x")
-        @assert x1 == Any[1]
-        x2 = read(fidr, "group2/x")
-        @assert x2 == Any[2]
+#         x1 = read(fidr, "group1/x")
+#         @assert x1 == Any[1]
+#         x2 = read(fidr, "group2/x")
+#         @assert x2 == Any[2]
         
-        close(fidr)
-    end
-end # compress in (true,false)
+#         close(fidr)
+#     end
+# end # compress in (true,false)
 
 for compress in (false,true)
     # object references in a write session
@@ -734,17 +734,17 @@ jldopen(fn, "r") do file
     for i = 1:5
         @test x[i].x.x == i
     end
-    @test typeof(read(file, "x6")).names == ()
+    @test HDF5.getnames(typeof(read(file, "x6"))) == (@compat Tuple{})
     @test reinterpret(UInt8, read(file, "x7")) == 0x77
 
     x = read(file, "x8")
     @test x.a.x == 2
     @test x.b.x.x == 3
-    @test typeof(x.c).names == ()
+    @test HDF5.getnames(typeof(x.c)) == (@compat Tuple{})
     @test reinterpret(UInt8, x.d) == 0x12
 
     x = read(file, "x9")
-    @test isa(x, Tuple)
+    @test isa(x, (@compat Tuple))
     @test length(x) == 3
     @test x[1].x == 1
     @test isa(x[2], Tuple)
@@ -753,7 +753,7 @@ jldopen(fn, "r") do file
     for i = 1:5
         @test x[2][2][i].x.x == i
     end
-    @test typeof(x[3]).names == ()
+    @test HDF5.getnames(typeof(x[3])) == (@compat Tuple{})
 end
 
 # Issue #176

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -77,7 +77,7 @@ sa_utf8 = [:α, :β]
 # SubArray (to test tuple type params)
 subarray = sub([1:5;], 1:5)
 # Array of empty tuples (to test tuple type params)
-arr_empty_tuple = ()[]
+arr_empty_tuple = (@compat Tuple{})[]
 immutable EmptyImmutable end
 emptyimmutable = EmptyImmutable()
 arr_emptyimmutable = [emptyimmutable]

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -228,10 +228,10 @@ g = fid["mygroup"]
 close(g)
 close(fid)
 
-# d = h5read(joinpath(test_path, "compound.h5"), "/data")
-# @assert typeof(d) == HDF5.HDF5Compound
-# @assert typeof(d.data) == Array{UInt8,1}
-# @assert length(d.data) == 128
-# @assert d.membertype == Type[Float64, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, Float64]
-# @assert d.membername == ASCIIString["wgt", "xyz", "uvw", "E"]
-# @assert d.memberoffset == UInt64[0x00, 0x08, 0x20, 0x38]
+d = h5read(joinpath(test_path, "compound.h5"), "/data")
+@assert typeof(d) == HDF5.HDF5Compound
+@assert typeof(d.data) == Array{UInt8,1}
+@assert length(d.data) == 128
+@assert d.membertype == Type[Float64, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, Float64]
+@assert d.membername == ASCIIString["wgt", "xyz", "uvw", "E"]
+@assert d.memberoffset == UInt64[0x00, 0x08, 0x20, 0x38]

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -187,7 +187,7 @@ end
 # Test reading multiple vars at once
 z = read(fr, "Float64", "Int16")
 @assert z == (3.2, 4)
-@assert typeof(z) == (Float64, Int16)
+@assert typeof(z) == @compat Tuple{Float64, Int16}
 # Test function syntax
 read(fr, "Float64") do x
 	@assert x == 3.2
@@ -232,6 +232,6 @@ d = h5read(joinpath(test_path, "compound.h5"), "/data")
 @assert typeof(d) == HDF5.HDF5Compound
 @assert typeof(d.data) == Array{UInt8,1}
 @assert length(d.data) == 128
-@assert d.membertype == Type[Float64, HDF5.FixedArray{Float64,(HDF5.DimSize{3},)}, HDF5.FixedArray{Float64,(HDF5.DimSize{3},)}, Float64]
+@assert d.membertype == Type[Float64, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, Float64]
 @assert d.membername == ASCIIString["wgt", "xyz", "uvw", "E"]
 @assert d.memberoffset == UInt64[0x00, 0x08, 0x20, 0x38]

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -228,10 +228,10 @@ g = fid["mygroup"]
 close(g)
 close(fid)
 
-d = h5read(joinpath(test_path, "compound.h5"), "/data")
-@assert typeof(d) == HDF5.HDF5Compound
-@assert typeof(d.data) == Array{UInt8,1}
-@assert length(d.data) == 128
-@assert d.membertype == Type[Float64, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, Float64]
-@assert d.membername == ASCIIString["wgt", "xyz", "uvw", "E"]
-@assert d.memberoffset == UInt64[0x00, 0x08, 0x20, 0x38]
+# d = h5read(joinpath(test_path, "compound.h5"), "/data")
+# @assert typeof(d) == HDF5.HDF5Compound
+# @assert typeof(d.data) == Array{UInt8,1}
+# @assert length(d.data) == 128
+# @assert d.membertype == Type[Float64, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, HDF5.FixedArray{Float64,(@compat Tuple{HDF5.DimSize{3}})}, Float64]
+# @assert d.membername == ASCIIString["wgt", "xyz", "uvw", "E"]
+# @assert d.memberoffset == UInt64[0x00, 0x08, 0x20, 0x38]


### PR DESCRIPTION
This PR allows to use `using HDF5` with the changes from https://github.com/JuliaLang/julia/commit/ef062117bab19959a6905b1bb6d7963b42dddea4
The package now loads in 0.4 master and loads + passes unit tests on 0.3 (when using https://github.com/JuliaLang/Compat.jl/pull/63), but the unit tests in 0.4 yield this error:
```
> ~/local/devdevjulia/julia test/runtests.jl
ERROR: LoadError: LoadError: MethodError: `one` has no method matching one(::Type{Any})
 in _mapreduce at reduce.jl:135
 in prod at reduce.jl:219
 in _setindex! at /Users/rene/.julia/v0.4/HDF5/src/plain.jl:1583
 in setindex! at /Users/rene/.julia/v0.4/HDF5/src/plain.jl:1618
 in include at ./boot.jl:250
 in include_from_node1 at ./loading.jl:129
 in include at ./boot.jl:250
 in include_from_node1 at loading.jl:129
 in process_options at ./client.jl:299
 in _start at ./client.jl:398
while loading /Users/rene/.julia/v0.4/HDF5/test/plain.jl, in expression starting on line 84
while loading /Users/rene/.julia/v0.4/HDF5/test/runtests.jl, in expression starting on line 3
```
It is caused by the array being passed to `prod` in https://github.com/rened/HDF5.jl/blob/master/src/plain.jl#L1583 being empty.

@timholy or @simonster, could you please take over from here? I don't know how to solve this properly.