### PR TITLE
Adding Union to method signature related to issue #236

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -1303,7 +1303,7 @@ function getindex(parent::Union(HDF5File, HDF5Group, HDF5Dataset), r::HDF5Refere
 end
 
 # Read compound type
-function read(obj::HDF5Dataset, ::Type{Array{HDF5Compound}})
+function read(obj::HDF5Dataset, ::Union(Type{Array{HDF5Compound}},Type{HDF5Compound}))
     t = datatype(obj)
     local sz = 0, n, membername, membertype, memberoffset, memberfiletype
     try
@@ -1550,7 +1550,7 @@ function getindex(dset::HDF5Dataset, indices::Union(Range{Int},Int)...)
     _getindex(dset,T, indices...)
 end
 function _getindex(dset::HDF5Dataset, T::Type, indices::Union(Range{Int},Int)...)
-    if !(T<:HDF5BitsKind)    
+    if !(T<:HDF5BitsKind)
         error("Dataset indexing (hyperslab) is available only for bits types")
     end
     dsel_id = hyperslab(dset, indices...)

--- a/test/jld_dataframe.jl
+++ b/test/jld_dataframe.jl
@@ -20,3 +20,15 @@ close(file)
 using Base.Test
 @test isequal(df, x)
 @test isequal(df2, y)
+
+# Testing issue #236
+fname = joinpath(tempdir(), "int_str_data.jld")
+df3 = DataFrames.DataFrame(A = [1:4;], B = ["M", "F", "F", "M"])
+file = jldopen(fname, "w")
+write(file, "df3", df3)
+close(file)
+file = jldopen(fname, "r")
+dump(file)
+x = read(file, "df3")
+@test isequal(df3, x)
+


### PR DESCRIPTION
Addressing issue #236, updating the method signature of read in line 1306 to be a Union Array{HDF5Compound} and HDF5Compound, and adding corresponding tests to test/jld_dataframe.jl
