### PR TITLE
fix mmap for 0.4

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -1421,7 +1421,7 @@ function readmmap{T}(obj::HDF5Dataset, ::Type{Array{T}})
     if offset == reinterpret(Hsize, convert(Hssize, -1))
         error("Error mmapping array")
     end
-    mmap_array(T, dims, fdio(fd), convert(FileOffset, offset))
+    Mmap.mmap(fdio(fd), Array{T,length(dims)}, dims, offset)
 end
 
 function readmmap(obj::HDF5Dataset)


### PR DESCRIPTION
Silences a deprecation warning on 0.4.

I put the version-checking logic directly in here, as importing all of mmap's functionality into Compat seems to be overkill.