### PR TITLE
Generalize read(::DataFile, name::T...) to T=ByteString

### DIFF
--- a/src/datafile.jl
+++ b/src/datafile.jl
@@ -28,7 +28,7 @@ macro write(fid, sym)
 end
 
 # Read a list of variables, read(parent, "A", "B", "x", ...)
-read(parent::DataFile, name::ASCIIString...) =
+read(parent::DataFile, name::ByteString...) =
 	tuple([read(parent, x) for x in name]...)
 
 # Read one or more variables and pass them to a function. This is

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,5 @@ runtest("plain.jl")
 runtest("readremote.jl")
 runtest("extend_test.jl")
 runtest("gc.jl")
+
+nothing


### PR DESCRIPTION
This avoids an ambiguity warning that (I think) appears only when precompiling.
But it seems like the right thing to do anyway, since the definition in
plain.jl also allows ByteString.