### PR TITLE
remove redundant register_blosc() call

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -507,7 +507,6 @@ end
 
 # Blosc compression:
 include("blosc_filter.jl")
-register_blosc()
 
 # heuristic chunk layout (return empty array to disable chunking)
 function heuristic_chunk(T, shape)


### PR DESCRIPTION
I noticed that `register_blosc()` was being called twice, once in the body of the module (wrong) and once in `__init__()` (right).  This removes the former.